### PR TITLE
Add dependencies for the Python environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ following these steps before your arrival at the workshop.
 
 ```
 conda config --add channels [some channels]
-conda create -n workshop python=2 [bunch of stuff]
+conda create -n workshop python=2 pip numpy scipy matplotlib ipython-notebook pandas netcdf4 dask xray
 ```
 
 If you have questions about these instructions, please contact


### PR DESCRIPTION
Users will want all of these installed for my session on [xray](http://xray.readthedocs.org/).

Some of these dependencies are implicitly included in others (e.g., numpy and pandas are requirements for xray) but it seems like a good idea to call them out explicitly.
